### PR TITLE
reverse the sorting so that oldest messages are added first...

### DIFF
--- a/chrome-logic-gmail.js
+++ b/chrome-logic-gmail.js
@@ -126,7 +126,8 @@ function listMessages(userId, query, callback) {
                 });
                 getPageOfMessages(request, result);
             } else {
-                callback(result); return;
+                var reversed = result.reverse();
+                callback(reversed); return;
             }
         });
     };


### PR DESCRIPTION
By reversing the message order, we get a more normal experience after import... eg, newest Notes are near the top of Keep instead of the bottom.